### PR TITLE
Output order in AIGER circuit

### DIFF
--- a/Sources/TransitionSystem/ExplicitState.swift
+++ b/Sources/TransitionSystem/ExplicitState.swift
@@ -57,13 +57,13 @@ extension ExplicitStateSolution: AigerRepresentable {
                 outputFunction[output] = (outputFunction[output] ?? Literal.False) | mustBeEnabled
             }
         }
-        // Check that all outputs are defined
         for output in specification.outputs {
-            assert(outputFunction[output] != nil)
-        }
-        for (output, condition) in outputFunction {
-            let aigLiteral = condition.accept(visitor: aigerVisitor)
-            aigerVisitor.addOutput(literal: aigLiteral, name: output)
+            if let condition = outputFunction[output] {
+                let aigLiteral = condition.accept(visitor: aigerVisitor)
+                aigerVisitor.addOutput(literal: aigLiteral, name: output)
+            } else {
+                fatalError("Output \(output) is not defined")
+            }
         }
 
         var latchFunction: [Proposition: Logic] = [:]


### PR DESCRIPTION
In my project, it would be useful if the order of outputs specified in the JSON input file is preserved in the AIGER circuit. I figured that this is currently not the case due to iterating over output-formula pairs in a dictionary. I propose to iterate over the outputs in the specification object to retrieve the output-formula pairs.

I look forward to your comments!