### PR TITLE
Optimize option

### DIFF
--- a/Sources/BoundedSynthesis/AigerInputSymbolicEncoding.swift
+++ b/Sources/BoundedSynthesis/AigerInputSymbolicEncoding.swift
@@ -60,6 +60,7 @@ public class AigerInputSymbolicEncoding<A: Automaton>: SingleParamaterSearch whe
                 assignments.removeValue(forKey: proposition)
             }
             self.instance = instance // .eval(assignment: assignments)
+            self.assignments = assignments
             solutionBound = bound
             return true
         }


### PR DESCRIPTION
When working with BoSy I found that the optimize option is not working correctly. For example, when running `./bosy.sh --synthesize --optimize Samples/simple_arbiter.bosy` the error `hasSolution() must be true before calling this function` is logged (Please find the full output attached.). This is because property `assignments` of class `AigerInputSymbolicEncoding` is `nil`. Setting the property in the `solve` method seems to solve the problem.

[output.txt](https://github.com/reactive-systems/bosy/files/6384505/output.txt)
