### PR TITLE
Fix Make error and Update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,20 +169,21 @@ Tools/aiger-ltl-model-checker:
 	cd Tools ; git clone https://github.com/reactive-systems/aiger-ltl-model-checker.git
 
 # cryptominisat
-Tools/cryptominisat5: Tools/cryptominisat-5.6.8/build
-	cp Tools/cryptominisat-5.6.8/build/cryptominisat5_simple Tools/cryptominisat5
+cms_version=5.7.0
+Tools/cryptominisat5: Tools/cryptominisat-$(cms_version)/build
+	cp Tools/cryptominisat-$(cms_version)/build/cryptominisat5_simple Tools/cryptominisat5
 
-Tools/cryptominisat-5.6.8/build: Tools/cryptominisat-5.6.8
-	mkdir Tools/cryptominisat-5.6.8/build
-	cd Tools/cryptominisat-5.6.8/build ; cmake -DCMAKE_BUILD_TYPE=Release -DSTATICCOMPILE=ON -DENABLE_PYTHON_INTERFACE=OFF ..
-	cd Tools/cryptominisat-5.6.8/build ; make -j4
+Tools/cryptominisat-$(cms_version)/build: Tools/cryptominisat-$(cms_version)
+	mkdir Tools/cryptominisat-$(cms_version)/build
+	cd Tools/cryptominisat-$(cms_version)/build ; cmake -DCMAKE_BUILD_TYPE=Release -DSTATICCOMPILE=ON -DENABLE_PYTHON_INTERFACE=OFF ..
+	cd Tools/cryptominisat-$(cms_version)/build ; make -j4
 
-Tools/cryptominisat-5.6.8: Tools/cryptominisat-5.6.8.tar.gz
-	cd Tools ; tar xzf cryptominisat-5.6.8.tar.gz
+Tools/cryptominisat-$(cms_version): Tools/cryptominisat-$(cms_version).tar.gz
+	cd Tools ; tar xzf cryptominisat-$(cms_version).tar.gz
 
-Tools/cryptominisat-5.6.8.tar.gz: Tools/.f
-	cd Tools ; curl -OL https://github.com/msoos/cryptominisat/archive/5.6.8.tar.gz
-	mv Tools/5.6.8.tar.gz Tools/cryptominisat-5.6.8.tar.gz
+Tools/cryptominisat-$(cms_version).tar.gz: Tools/.f
+	cd Tools ; curl -OL https://github.com/msoos/cryptominisat/archive/$(cms_version).tar.gz
+	mv Tools/$(cms_version).tar.gz Tools/cryptominisat-$(cms_version).tar.gz
 
 # cvc4
 Tools/cvc4: Tools/cvc4-1.5/builds/bin/cvc4

--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ The following packages need to be installed in order to build BoSy with all depe
 
 For CAQE, you also need Rust installed.
 
-#### Ubuntu 16.04
+One may also need to install the `python-is-python3` package.
+#### Ubuntu 20.04
 
 ```bash
-apt-get install bison build-essential clang cmake curl flex gcc git libantlr3c-dev libbdd-dev libboost-program-options-dev libicu-dev libreadline-dev mercurial psmisc unzip vim-common wget zlib1g-dev libsqlite3-dev
+apt-get install bison build-essential clang cmake curl flex gcc git libantlr3c-dev libbdd-dev libboost-program-options-dev libicu-dev libreadline-dev mercurial psmisc unzip vim-common wget zlib1g-dev libsqlite3-dev python3-distutils
+# for rust
+apt-get install rustc cargo
 # Haskell stack
 curl -sSL https://get.haskellstack.org/ | sh
-```
-
+``` 
 #### macOS
 
 ```


### PR DESCRIPTION
Bumped cmsat to 5.7.0 for now, since old version wouldn't build. 
For libsolve this is done via a `sed` command. I'll fix that properly later, only needs a PR against Leanders  repo
Updated README with needed system packages and notice about python